### PR TITLE
Fix for having UINavigationViewController subclasses

### DIFF
--- a/UINavigationControllerWithCompletionBlock.podspec
+++ b/UINavigationControllerWithCompletionBlock.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
         s.name         = 'UINavigationControllerWithCompletionBlock'
-        s.version = '0.0.7'
+        s.version = '0.0.7.1-vinted'
         s.requires_arc = true
         s.author = {
                 'Morissard Jérome' => 'morissardj@gmail.com'
@@ -10,8 +10,8 @@ Pod::Spec.new do |s|
         s.license      = { :type => 'MIT' }
         s.homepage = 'https://github.com/leverdeterre/UINavigationControllerWithCompletionBlock'
         s.source = {
-        :git => 'https://github.com/leverdeterre/UINavigationControllerWithCompletionBlock.git',
-        :tag => '0.0.7'
+        :git => 'https://github.com/vinted/UINavigationControllerWithCompletionBlock',
+        :tag => '0.0.7.1-vinted'
         }
         s.source_files = 'UINavigationControllerWithCompletionBlock/UINavigationControllerWithCompletionBlock/UINavigationControllerWithCompletionBlock/*'
   	s.dependency 'JRSwizzle', '~> 1.0'

--- a/UINavigationControllerWithCompletionBlock/UINavigationControllerWithCompletionBlock/UINavigationControllerWithCompletionBlock/UINavigationController+CompletionBlock.m
+++ b/UINavigationControllerWithCompletionBlock/UINavigationControllerWithCompletionBlock/UINavigationControllerWithCompletionBlock/UINavigationController+CompletionBlock.m
@@ -146,12 +146,12 @@ typedef NS_ENUM(NSUInteger, UINavigationControllerState) {
 
 + (UINavigationControllerSwizzlingOption)swizzlingOption
 {
-    return [objc_getAssociatedObject(self, _cmd) intValue];
+    return [objc_getAssociatedObject([UINavigationController class], _cmd) intValue];
 }
 
 + (void)setSwizzlingOption:(UINavigationControllerSwizzlingOption)swizzlingOption
 {
-    objc_setAssociatedObject(self, @selector(swizzlingOption),@(swizzlingOption), OBJC_ASSOCIATION_RETAIN);
+    objc_setAssociatedObject([UINavigationController class], @selector(swizzlingOption),@(swizzlingOption), OBJC_ASSOCIATION_RETAIN);
 }
 
 - (id<UINavigationControllerDelegate>)nextDelegate


### PR DESCRIPTION
Problem:

This class uses self for storing swizzling options :

```
+ (UINavigationControllerSwizzlingOption)swizzlingOption
{
    return [objc_getAssociatedObject(self, _cmd) intValue];
}
+ (void)setSwizzlingOption:(UINavigationControllerSwizzlingOption)swizzlingOption
{
    objc_setAssociatedObject(self, @selector(swizzlingOption),@(swizzlingOption), OBJC_ASSOCIATION_RETAIN);
}
```

And case:

```
[UINavigationController activateSwizzling];

NavigationControllerSubclass navC = ...
[navC pushViewController:...];
causes recursion (NavigationControllerSubclass hasn't any swizzlingOptions set but it's methods are swizzled)
```

To avoid recursion we have hack in app delegate:

```
[UnrotatedNavController activateSwizzling]
```

that fixes swizzlingOptions for UnrotatedNavController class, but deswizzles UINavigationViewController methods :D (take a look at activateSwizzlingWithOptions:)

So we still have "addSubview" crashes.

Not sure if it sounds clear :)
